### PR TITLE
fix: Remove automatic scroll to weather chart on page load

### DIFF
--- a/app/weather/page.tsx
+++ b/app/weather/page.tsx
@@ -131,11 +131,6 @@ const WeatherPage: React.FC = () => {
 		}
 	}, []);
 
-	useEffect(() => {
-		if (weatherData) {
-			scrollToChart();
-		}
-	}, [weatherData, scrollToChart]);
 
 	return (
 		<div className="p-8 bg-background min-h-screen">


### PR DESCRIPTION
## Summary
- Remove automatic scroll behavior that caused weather page to jump to chart section when data loaded
- Preserve manual scroll functionality through existing "See Weather Trends" button
- Improve user experience by keeping page at top on initial load

## Changes Made
- **File**: `app/weather/page.tsx`
- **Change**: Removed `useEffect` hook (lines 134-138) that automatically triggered `scrollToChart()` when weather data loaded
- **Preserved**: Manual scroll function and button for user-controlled navigation to charts

## Problem Solved
Users reported that the weather page would automatically scroll down to the chart section upon loading, creating a jarring experience. The page now loads normally at the top, allowing users to scroll manually if desired.

## Test Plan
- [x] Weather page loads at top of page (scroll position Y=0)
- [x] No automatic scrolling occurs when weather data loads
- [x] Manual "See Weather Trends" button still functions correctly
- [x] All weather data displays properly without errors
- [x] No ESLint warnings or errors
- [x] Comprehensive browser testing with Playwright

## Technical Details
The automatic scroll was caused by a `useEffect` that watched for `weatherData` changes and immediately called `scrollToChart()`. This has been removed while keeping the scroll function available for manual use.

**Before**: Page automatically scrolled to chart on data load
**After**: Page stays at top, user controls when to scroll to charts